### PR TITLE
Add requestNotificationAuthorizationAsync API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Batch Cordova Plugin
 
+## UPCOMING
+
+**Push**
+- Added `batch.push.requestNotificationAuthorizationAsync` to request notification authorization and return a promise that resolve with the authorization result.
+
 ## 7.0.0
 
 **Plugin**

--- a/dist/src/android/interop/Action.java
+++ b/dist/src/android/interop/Action.java
@@ -30,6 +30,7 @@ public enum Action
     PUSH_SET_IOSSHOW_FOREGROUND("push.setIOSShowForegroundNotifications"),
     PUSH_IOS_REFRESH_TOKEN("push.iOS.refreshToken"),
     PUSH_REQUEST_AUTHORIZATION("push.requestAuthorization"),
+    PUSH_REQUEST_AUTHORIZATION_ASYNC("push.requestAuthorizationAsync"),
     PUSH_IOS_REQUEST_PROVISIONAL_AUTH("push.iOS.requestProvisionalAuthorization"),
 	PROFILE_EDIT("profile.edit"),
 	PROFILE_IDENTIFY("profile.identify"),

--- a/dist/src/android/interop/Bridge.java
+++ b/dist/src/android/interop/Bridge.java
@@ -158,6 +158,8 @@ public class Bridge {
             case PUSH_REQUEST_AUTHORIZATION:
                 requestAuthorization(activity);
                 break;
+            case PUSH_REQUEST_AUTHORIZATION_ASYNC:
+                return convertModernPromiseToLegacy(requestAuthorizationAsync(activity));
             case PUSH_IOS_REQUEST_PROVISIONAL_AUTH:
                 // iOS only, do nothing
                 return null;
@@ -332,6 +334,13 @@ public class Bridge {
     private static void requestAuthorization(Activity activity) {
         // Ask for android 13 notification permission
         Batch.Push.requestNotificationPermission(activity);
+    }
+
+    private static SimplePromise<Object> requestAuthorizationAsync(Activity activity) {
+        return new SimplePromise<>(promise ->
+                Batch.Push.requestNotificationPermission(activity, granted ->
+                        promise.resolve(Collections.singletonMap("granted", granted)))
+        );
     }
 
     // endregion

--- a/dist/src/ios/interop/BatchBridge.m
+++ b/dist/src/ios/interop/BatchBridge.m
@@ -226,6 +226,11 @@ static dispatch_once_t onceToken;
         [BatchPush requestNotificationAuthorization];
     }
 
+    else if ([action caseInsensitiveCompare:PUSH_REQUEST_AUTHORIZATION_ASYNC] == NSOrderedSame)
+    {
+        return [self convertPromiseToLegacyBridge:[self requestAuthorizationAsync]];
+    }
+
     else if ([action caseInsensitiveCompare:PUSH_REQUEST_PROVISIONAL_AUTH] == NSOrderedSame)
     {
         [BatchPush requestProvisionalNotificationAuthorization];
@@ -370,6 +375,24 @@ static dispatch_once_t onceToken;
 
 #pragma mark -
 #pragma mark Helpers
+
++ (BACSimplePromise<NSDictionary*> *)requestAuthorizationAsync
+{
+    BACSimplePromise<NSDictionary*> *resultPromise = [BACSimplePromise new];
+
+    [BatchPush requestNotificationAuthorizationWithCompletionHandler:^(BOOL granted, NSError * _Nullable error) {
+        if (error != nil) {
+            [resultPromise reject:error];
+            return;
+        }
+
+        [resultPromise resolve:@{
+            @"granted": @(granted)
+        }];
+    }];
+
+    return resultPromise;
+}
 
 // Converts a "new format" Promise matching newer bridges like Flutter (can be resolved to a Dictionary, or rejected)
 // to a "legacy" one that is resolved with a string and shouldn't reject.

--- a/dist/src/ios/interop/BatchBridgeShared.h
+++ b/dist/src/ios/interop/BatchBridgeShared.h
@@ -28,6 +28,7 @@ if (error == NULL) {\
 
 #define PUSH_REFRESH_TOKEN                  @"push.iOS.refreshToken"
 #define PUSH_REQUEST_AUTHORIZATION          @"push.requestAuthorization"
+#define PUSH_REQUEST_AUTHORIZATION_ASYNC    @"push.requestAuthorizationAsync"
 #define PUSH_REQUEST_PROVISIONAL_AUTH       @"push.iOS.requestProvisionalAuthorization"
 
 #define DISMISS_NOTIFS                      @"push.dismissNotifications"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -19,6 +19,7 @@ export enum Push {
   ClearBadge = "push.clearBadge",
   RefreshToken = "push.iOS.refreshToken",
   RequestAuthorization = "push.requestAuthorization",
+  RequestAuthorizationAsync = "push.requestAuthorizationAsync",
   RequestProvisionalAuthorization = "push.iOS.requestProvisionalAuthorization",
 }
 

--- a/src/batchStub.ts
+++ b/src/batchStub.ts
@@ -19,6 +19,9 @@ class PushStub implements BatchSDK.PushModule {
 
   public refreshToken() {}
   public requestNotificationAuthorization() {}
+  public requestNotificationAuthorizationAsync(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
   public requestProvisionalNotificationAuthorization() {}
   public setiOSShowForegroundNotifications(_showForeground: boolean) {}
   public setAndroidShowNotifications(_show: boolean) {}

--- a/src/modules/push.ts
+++ b/src/modules/push.ts
@@ -34,6 +34,13 @@ export class PushModule implements BatchSDK.PushModule {
     sendToBridge(null, PushActions.RequestAuthorization, null);
   }
 
+  public async requestNotificationAuthorizationAsync(): Promise<boolean> {
+    const { granted } = (await invokeModernBridge(
+      PushActions.RequestAuthorizationAsync
+    )) as { granted: boolean };
+    return granted;
+  }
+
   public requestProvisionalNotificationAuthorization(): void {
     sendToBridge(null, PushActions.RequestProvisionalAuthorization, null);
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -368,15 +368,29 @@ export declare namespace BatchSDK {
     refreshToken(): void;
 
     /**
-     * Call this method to trigger the iOS popup that asks the user if they want
-     * to allow notifications to be displayed, then get a Push token.
-     * The default registration is made with Badge, Sound and Alert.
+     * Call this method to trigger the native notification authorization request that asks the user if they want
+     * to allow notifications to be displayed.
+     * The default registration is made with Badge, Sound, and Alert.
      * You should call this at a strategic moment, like at the end of your onboarding.
      *
-     * Batch will automatically ask for a push token if the user replies positively.
+     * On iOS, Batch will automatically ask for a push token if the user replies positively.
      * You should then call `refreshToken` on every application start.
      */
     requestNotificationAuthorization(): void;
+
+    /**
+     * Call this method to trigger the native notification authorization request and
+     * get the resulting grant state as a promise.
+     *
+     * The default registration is made with Badge, Sound, and Alert.
+     *
+     * You should call this at a strategic moment, like at the end of your onboarding.
+     *
+     * On iOS, Batch will automatically ask for a push token if the user replies positively.
+     * You should then call `refreshToken` on every application start.
+     * @return A promise resolving to whether notifications were authorized
+     */
+    requestNotificationAuthorizationAsync(): Promise<boolean>;
 
     /**
      * Call this method to ask iOS for a provisional notification authorization.


### PR DESCRIPTION
- Added `batch.push.requestNotificationAuthorizationAsync` to request notification authorization and return a promise that resolve with the authorization result.
