### PR TITLE
SPM Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Batch Cordova Plugin
 
+## UPCOMING
+
+**iOS**
+- Added Swift Package Manager (SPM) support. Projects using cordova-ios 8+ can now resolve the Batch SDK via SPM instead of CocoaPods. CocoaPods remain the fallback for older cordova-ios versions.
+
 ## 7.1.0
 
 **Plugin**

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,2 +1,7 @@
 www/batch.js
 index.d.ts
+
+# Ignore Swift generated files
+.build
+.swiftpm
+Package.resolved

--- a/dist/Package.swift
+++ b/dist/Package.swift
@@ -9,14 +9,14 @@ let package = Package(
         .library(name: "@batch.com/cordova-plugin", targets: ["BatchCordovaPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.3.4"),
+        .package(url: "https://github.com/apache/cordova-ios.git", from: "8.1.0"),
         .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", from: "3.3.0")
     ],
     targets: [
         .target(
             name: "BatchCordovaPlugin",
             dependencies: [
-                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "Batch", package: "Batch-iOS-SDK")
             ],
             path: "src/ios",

--- a/dist/Package.swift
+++ b/dist/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "@batch.com/cordova-plugin",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(name: "@batch.com/cordova-plugin", targets: ["BatchCordovaPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.3.4"),
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", from: "3.3.0")
+    ],
+    targets: [
+        .target(
+            name: "BatchCordovaPlugin",
+            dependencies: [
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "Batch", package: "Batch-iOS-SDK")
+            ],
+            path: "src/ios",
+            resources: [],
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath("interop")
+            ]
+        )
+    ]
+)

--- a/dist/plugin.xml
+++ b/dist/plugin.xml
@@ -77,7 +77,7 @@
 
     </platform>
 
-    <platform name="ios">
+    <platform name="ios" package="swift">
 
         <preference name="BATCHSDK_IOS_VERSION" default="~> 3.3"/>
 
@@ -130,7 +130,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Batch" spec="$BATCHSDK_IOS_VERSION" />
+                <pod name="Batch" spec="$BATCHSDK_IOS_VERSION" nospm="true" />
             </pods>
         </podspec>
 

--- a/dist/src/ios/include/BatchCordovaPlugin.h
+++ b/dist/src/ios/include/BatchCordovaPlugin.h
@@ -1,0 +1,1 @@
+#import "../BatchCordovaPlugin.h"


### PR DESCRIPTION
**iOS**
- Added Swift Package Manager (SPM) support. Projects using cordova-ios 8+ can now resolve the Batch SDK via SPM instead of CocoaPods. CocoaPods remain the fallback for older cordova-ios versions.