### PR TITLE
Release 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Batch Cordova Plugin
 
+## UPCOMING
+
+**iOS**
+- Added Swift Package Manager (SPM) support. Projects using cordova-ios 8+ can now resolve the Batch SDK via SPM instead of CocoaPods. CocoaPods remain the fallback for older cordova-ios versions.
+
 ## 7.1.0
 
 **Plugin**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 Batch Cordova Plugin
 
-## UPCOMING
+## 7.2.0
+
+**Plugin**
+- Updated Batch to 3.4.
 
 **iOS**
-- Added Swift Package Manager (SPM) support. Projects using cordova-ios 8+ can now resolve the Batch SDK via SPM instead of CocoaPods. CocoaPods remain the fallback for older cordova-ios versions.
+- Added Swift Package Manager (SPM) support. Projects using cordova-ios 8+ can now resolve the Batch SDK via SPM instead of CocoaPods. CocoaPods remain the fallback for older cordova-ios versions. Capacitor iOS projects using SPM will also resolve the Batch SDK dependency.
 
 ## 7.1.0
 

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,2 +1,7 @@
 www/batch.js
 index.d.ts
+
+# Ignore Swift generated files
+.build
+.swiftpm
+Package.resolved

--- a/dist/Package.swift
+++ b/dist/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", from: "8.1.0"),
-        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", from: "3.3.0")
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", from: "3.4.0")
     ],
     targets: [
         .target(

--- a/dist/Package.swift
+++ b/dist/Package.swift
@@ -9,14 +9,14 @@ let package = Package(
         .library(name: "@batch.com/cordova-plugin", targets: ["BatchCordovaPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.3.4"),
+        .package(url: "https://github.com/apache/cordova-ios.git", from: "8.1.0"),
         .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", from: "3.3.0")
     ],
     targets: [
         .target(
             name: "BatchCordovaPlugin",
             dependencies: [
-                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "cordova-ios"),
                 .product(name: "Batch", package: "Batch-iOS-SDK")
             ],
             path: "src/ios",

--- a/dist/Package.swift
+++ b/dist/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "@batch.com/cordova-plugin",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(name: "@batch.com/cordova-plugin", targets: ["BatchCordovaPlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.3.4"),
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK.git", from: "3.3.0")
+    ],
+    targets: [
+        .target(
+            name: "BatchCordovaPlugin",
+            dependencies: [
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "Batch", package: "Batch-iOS-SDK")
+            ],
+            path: "src/ios",
+            resources: [],
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath("interop")
+            ]
+        )
+    ]
+)

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch.com/cordova-plugin",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Batch.com SDK Cordova/Ionic plugin for Android and iOS",
   "types": "index.d.ts",
   "repository": {
@@ -67,6 +67,11 @@
       "cordova-ios": ">=6.0.0"
     },
     "7.1.0": {
+      "cordova": ">=9.0.0",
+      "cordova-android": ">=9.0.0",
+      "cordova-ios": ">=6.0.0"
+    },
+    "7.2.0": {
       "cordova": ">=9.0.0",
       "cordova-android": ">=9.0.0",
       "cordova-ios": ">=6.0.0"

--- a/dist/plugin.xml
+++ b/dist/plugin.xml
@@ -77,7 +77,7 @@
 
     </platform>
 
-    <platform name="ios">
+    <platform name="ios" package="swift">
 
         <preference name="BATCHSDK_IOS_VERSION" default="~> 3.3"/>
 
@@ -130,7 +130,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Batch" spec="$BATCHSDK_IOS_VERSION" />
+                <pod name="Batch" spec="$BATCHSDK_IOS_VERSION" nospm="true" />
             </pods>
         </podspec>
 

--- a/dist/plugin.xml
+++ b/dist/plugin.xml
@@ -19,7 +19,7 @@
 
     <platform name="android">
 
-        <preference name="BATCHSDK_ANDROID_VERSION" default="3.3.+"/>
+        <preference name="BATCHSDK_ANDROID_VERSION" default="3.4.+"/>
 
         <!-- This should be 1.0.0 forever, we leave it configurable just in case another version needs to be used in an app -->
         <preference name="BATCHSDK_ANDROID_LOCALBROADCAST_VERSION" default="1.0.0"/>
@@ -79,7 +79,7 @@
 
     <platform name="ios" package="swift">
 
-        <preference name="BATCHSDK_IOS_VERSION" default="~> 3.3"/>
+        <preference name="BATCHSDK_IOS_VERSION" default="~> 3.4"/>
 
         <config-file target="config.xml" parent="/*">
             <feature name="Batch">

--- a/dist/plugin.xml
+++ b/dist/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="@batch.com/cordova-plugin"
-        version="7.1.0">
+        version="7.2.0">
     <engines>
         <engine name="cordova" version=">=9.0.0" />
         <engine name="cordova-android" version=">=9.0.0" />

--- a/dist/src/android/BatchCordovaPlugin.java
+++ b/dist/src/android/BatchCordovaPlugin.java
@@ -41,7 +41,7 @@ public class BatchCordovaPlugin extends CordovaPlugin implements Callback, Logge
 
     private static final String PLUGIN_VERSION_ENVIRONEMENT_VAR = "batch.plugin.version";
 
-    private static final String PLUGIN_VERSION = "Cordova/7.1.0";
+    private static final String PLUGIN_VERSION = "Cordova/7.2.0";
 
     /**
      * Key used to add extra to an intent to prevent it to be used more than once to compute opens

--- a/dist/src/ios/BatchCordovaPlugin.h
+++ b/dist/src/ios/BatchCordovaPlugin.h
@@ -11,7 +11,7 @@
 #import "BatchBridge.h"
 #import "BatchBridgeCallback.h"
 
-#define PluginVersion "Cordova/7.1.0"
+#define PluginVersion "Cordova/7.2.0"
 
 @interface BatchCordovaPlugin : CDVPlugin <BatchBridgeCallback, BatchLoggerDelegate, BatchMessagingDelegate>
 

--- a/dist/src/ios/include/BatchCordovaPlugin.h
+++ b/dist/src/ios/include/BatchCordovaPlugin.h
@@ -1,0 +1,1 @@
+#import "../BatchCordovaPlugin.h"


### PR DESCRIPTION
## 7.2.0

**Plugin**
- Updated Batch to 3.4.

**iOS**
- Added Swift Package Manager (SPM) support. Projects using cordova-ios 8+ can now resolve the Batch SDK via SPM instead of CocoaPods. CocoaPods remain the fallback for older cordova-ios versions. Capacitor iOS projects using SPM will also resolve the Batch SDK dependency.